### PR TITLE
Improve task breakdown prompt for better scoping and pushback

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -60,7 +60,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   // Route to appropriate handler with exhaustive matching
   switch (tool.name) {
     case "suggest_issues":
-      return await handleSuggestIssues(validatedArgs as SuggestIssuesInput);
+      return await handleSuggestIssues(validatedArgs as SuggestIssuesInput, taskStore);
 
     case "save_task_example":
       return await handleSaveTaskExample(

--- a/packages/mcp/src/lib/mcp.ts
+++ b/packages/mcp/src/lib/mcp.ts
@@ -4,8 +4,14 @@ import type { TaskExampleStorage } from "./storage-interface.js";
 
 // Tool implementation functions with dependencies passed in
 
-export async function handleSuggestIssues(args: SuggestIssuesInput) {
-  const plan = await generate_plan(args.taskDescription, args.context);
+export async function handleSuggestIssues(
+  args: SuggestIssuesInput,
+  taskStore: TaskExampleStorage
+) {
+  // Fetch relevant examples based on the task description
+  const examples = await taskStore.searchSimilarExamples(args.taskDescription, 3);
+  
+  const plan = await generate_plan(args.taskDescription, args.context, examples);
 
   if (plan.needsClarification) {
     return {

--- a/packages/mcp/src/prompts/plan.txt
+++ b/packages/mcp/src/prompts/plan.txt
@@ -1,29 +1,48 @@
 # Task Breakdown Assistant
 
-Break down large tasks into 2-4 manageable work items (~30 minutes each). Don't over-engineer simple changes.
+Break down tasks into well-scoped, parallelizable work items. Push back on underspecified or over-aggressive requests.
 
-## Core Principles
-- **One logical change = one issue**: Don't split naturally connected work
-- **Simple changes = simple issues**: Don't turn 10-minute changes into multi-issue epics
-- **Avoid enterprise over-engineering**: Not every aspect needs its own ticket
-- **Complete feature delivery**: Each issue should deliver working, tested functionality
+## Scoping Guidelines
+- **Target 200-300 line changes per issue**: Large enough to be meaningful, small enough to review
+- **Include semantic completeness**: Tests, types, documentation in the same issue as implementation
+- **Enable parallel work**: Issues should have minimal dependencies on each other
+- **One logical unit = one issue**: Don't artificially split cohesive functionality
+- **Reject underspecified tasks**: Push back if requirements are vague or missing critical details
+
+## Quality Gates
+**BEFORE breaking down, verify:**
+- Requirements are specific and actionable
+- Success criteria are clear and measurable  
+- Technical approach is feasible within scope
+- Dependencies between issues are minimal
+
+**PUSH BACK if:**
+- Task description is too vague ("make it better", "add some features")
+- Requirements change scope mid-breakdown
+- Estimated effort exceeds reasonable bounds (>1000 line changes)
+- Critical technical details are missing
 
 Return your response in either one of the following formats
 
-1. Breakdown: If no further clarification is needed
+1. **Breakdown**: If requirements are clear and well-scoped
 <issues>
 <issue>
-Single paragraph describing one complete logical change. Keep it simple for simple changes.
+**Title**: Clear, specific issue title
+**Scope**: Estimated line changes (~200-300)
+**Description**: Complete logical change including implementation, tests, types, and documentation
+**Acceptance Criteria**: Specific, measurable outcomes
+**Dependencies**: What this blocks/is blocked by
 </issue>
 </issues>
 
-Clarification: If further clarification is needed
-<clarification>
-What specific details do you need?
-</clarification>
+2. **Pushback**: If task needs refinement
+<pushback>
+**Problem**: Specific issue with the request (too vague, over-scoped, missing details)
+**Needed**: What specific information or refinement is required
+**Suggestion**: How to improve the task specification
+</pushback>
 
 Here is the task and issue for reference
-
 
 <task>
 {task}
@@ -32,3 +51,11 @@ Here is the task and issue for reference
 <context>
 {context}
 </context>
+
+{examples:if_not_empty}
+## Similar Examples
+
+Here are some similar tasks and how they were broken down:
+
+{examples}
+{/examples:if_not_empty}


### PR DESCRIPTION
## Problem

The current task breakdown prompt was letting through underspecified and over-aggressive requests, leading to poorly scoped issues that were difficult to review and work on in parallel.

## Solution

Enhanced the prompt with:

### Better Scoping Guidelines
- **200-300 line change targets** for proper issue sizing
- **Semantic completeness** - tests, types, docs included in same issue
- **Parallel work enablement** - minimal dependencies between issues

### Quality Gates
- Requirements verification before breakdown
- Clear pushback conditions for vague/over-scoped tasks
- Technical feasibility checks

### Improved Output Format
- Structured issue format with scope estimates
- Dependency tracking for parallel work
- Clear acceptance criteria

## Changes
- Enhanced `packages/mcp/src/prompts/plan.txt` with quality gates and pushback triggers
- Added explicit scoping guidelines and line change targets
- Restructured output format for better issue tracking

## Impact
- Better scoped issues (~200-300 line changes)
- Clearer pushback on underspecified requests  
- More parallelizable work with dependency tracking
- Complete semantic units (implementation + tests + types together)

---

<!-- mesa-description-start -->
## TL;DR
Enhanced the AI's task breakdown prompt with better scoping guidelines and quality gates, and added few-shot examples to improve the quality and specificity of generated issues.

## Why we made these changes
To address issues with underspecified and over-aggressive AI-generated task breakdowns, which resulted in poorly scoped issues difficult to review and parallelize. The goal is to produce better-scoped, semantically complete, and parallelizable work items.

## What changed?
- `packages/mcp/src/prompts/plan.txt`: Significantly updated the prompt with new scoping guidelines, quality gates, improved output format, and pushback conditions.
- `packages/mcp/src/lib/mcp.ts`: Updated `handleSuggestIssues` to fetch and pass relevant task examples from a `taskStore`.
- `packages/mcp/src/lib/plan.ts`: Enhanced `generate_plan` to accept an `examples` parameter for dynamic prompt inclusion.
- `packages/mcp/src/index.ts`: Updated `handleSuggestIssues` call to pass `taskStore`.

## Validation
No specific validation steps were detailed in the PR description. Implicitly, the changes aim to improve the quality of AI-generated task breakdowns, which would be validated through observation of generated issues.
<!-- mesa-description-end -->